### PR TITLE
fix: 修复 README 中 cd 目录路径错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ KeepTrack是一个用于生成自定义跑步运动轨迹数据（FIT格式）�
 1. **克隆项目到本地**
    ```bash
     git clone https://github.com/IAMAI-Dev/KeepTrack.git
-    cd KeepTrack/code
+    cd KeepTrack
    ```
 
 2. **安装依赖**


### PR DESCRIPTION
## 变更说明

- 修复 README 安装步骤中 `cd` 目录路径错误

## 关联 Issue

- 无

## 修改内容

- [README.md](README.md#L21)：将 `cd KeepTrack/code` 修正为 `cd KeepTrack`
- 项目根目录下不存在 `code` 子目录，克隆后直接 `cd KeepTrack` 即可进入项目

## 测试情况

- [x] 已确认 `README.md` 中无其他 `code` 路径引用
- [x] 已确认文档更新无误

## 补充说明

- 项目结构本身没有 `code` 文件夹，这是最初从某个子目录结构模板复制过来时遗留的错误
